### PR TITLE
Symfony4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 .DS_Store
 phpunit.xml
 cli-config.php
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,7 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
+  - 7.2
 env:
   - CONTAINER_CONFIG=Tests/Resources/config/services.xml
 before_script:

--- a/Controller/AuthorizeController.php
+++ b/Controller/AuthorizeController.php
@@ -3,15 +3,13 @@
 namespace OAuth2\ServerBundle\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
+use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 
 class AuthorizeController extends Controller
 {
     /**
-     * @Route("/authorize", name="_authorize_validate")
-     * @Method({"GET"})
+     * @Route("/authorize", name="_authorize_validate", methods={"GET"})
      * @Template("OAuth2ServerBundle:Authorize:authorize.html.twig")
      */
     public function validateAuthorizeAction()

--- a/Controller/TokenController.php
+++ b/Controller/TokenController.php
@@ -3,7 +3,7 @@
 namespace OAuth2\ServerBundle\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 
 class TokenController extends Controller
 {

--- a/Controller/VerifyController.php
+++ b/Controller/VerifyController.php
@@ -3,7 +3,7 @@
 namespace OAuth2\ServerBundle\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
 class VerifyController extends Controller

--- a/Manager/ClientManager.php
+++ b/Manager/ClientManager.php
@@ -3,6 +3,7 @@
 namespace OAuth2\ServerBundle\Manager;
 
 use Doctrine\ORM\EntityManager;
+use OAuth2\ServerBundle\Entity\Client;
 use OAuth2\ServerBundle\Exception\ScopeNotFoundException;
 
 class ClientManager
@@ -35,7 +36,7 @@ class ClientManager
      */
     public function createClient($identifier, array $redirect_uris = array(), array $grant_types = array(), array $scopes = array())
     {
-        $client = new \OAuth2\ServerBundle\Entity\Client();
+        $client = new Client();
         $client->setClientId($identifier);
         $client->setClientSecret($this->generateSecret());
         $client->setRedirectUri($redirect_uris);
@@ -62,7 +63,7 @@ class ClientManager
     /**
      * Creates a secret for a client
      *
-     * @return A secret
+     * @return string A secret
      */
     protected function generateSecret()
     {

--- a/Manager/ScopeManager.php
+++ b/Manager/ScopeManager.php
@@ -3,6 +3,7 @@
 namespace OAuth2\ServerBundle\Manager;
 
 use Doctrine\ORM\EntityManager;
+use OAuth2\ServerBundle\Entity\Scope;
 
 class ScopeManager implements ScopeManagerInterface
 {
@@ -28,7 +29,7 @@ class ScopeManager implements ScopeManagerInterface
           return $scopeObject;
         }
 
-        $scopeObject = new \OAuth2\ServerBundle\Entity\Scope();
+        $scopeObject = new Scope();
         $scopeObject->setScope($scope);
         $scopeObject->setDescription($description);
 

--- a/Manager/ScopeManagerInterface.php
+++ b/Manager/ScopeManagerInterface.php
@@ -3,6 +3,7 @@
 namespace OAuth2\ServerBundle\Manager;
 
 use Doctrine\ORM\EntityManager;
+use OAuth2\ServerBundle\Entity\Scope;
 
 interface ScopeManagerInterface
 {

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -23,7 +23,7 @@
         <parameter key="oauth2.server.config" type="collection" />
     </parameters>
     <services>
-        <service id="oauth2.server" class="%oauth2.server.class%">
+        <service id="oauth2.server" class="%oauth2.server.class%" public="true">
             <argument type="collection">
                 <argument key="client_credentials" type="service" id="oauth2.storage.client_credentials" />
                 <argument key="access_token" type="service" id="oauth2.storage.access_token" />
@@ -36,57 +36,57 @@
             </argument>
             <argument>%oauth2.server.config%</argument>
         </service>
-        <service id="oauth2.request" class="%oauth2.request.class%">
+        <service id="oauth2.request" class="%oauth2.request.class%" public="true">
             <factory class="OAuth2\HttpFoundationBridge\Request" method="createFromRequestStack" />
             <argument type="service" id="request_stack"/>
         </service>
-        <service id="oauth2.response" class="%oauth2.response.class%"/>
-        <service id="oauth2.user_provider" class="%oauth2.user_provider.class%">
+        <service id="oauth2.response" class="%oauth2.response.class%" public="true" />
+        <service id="oauth2.user_provider" class="%oauth2.user_provider.class%" public="true">
             <argument type="service" id="doctrine.orm.entity_manager"/>
             <argument type="service" id="security.encoder_factory"/>
         </service>
-        <service id="oauth2.scope_manager" class="%oauth2.scope_manager.class%">
+        <service id="oauth2.scope_manager" class="%oauth2.scope_manager.class%" public="true">
             <argument type="service" id="doctrine.orm.entity_manager"/>
         </service>
-        <service id="oauth2.storage.client_credentials" class="%oauth2.storage.client_credentials.class%">
+        <service id="oauth2.storage.client_credentials" class="%oauth2.storage.client_credentials.class%" public="true">
             <argument type="service" id="doctrine.orm.entity_manager"/>
         </service>
-        <service id="oauth2.storage.authorization_code" class="%oauth2.storage.authorization_code.class%">
+        <service id="oauth2.storage.authorization_code" class="%oauth2.storage.authorization_code.class%" public="true">
             <argument type="service" id="doctrine.orm.entity_manager"/>
         </service>
-        <service id="oauth2.storage.user_credentials" class="%oauth2.storage.user_credentials.class%">
+        <service id="oauth2.storage.user_credentials" class="%oauth2.storage.user_credentials.class%" public="true">
             <argument type="service" id="doctrine.orm.entity_manager"/>
             <argument type="service" id="oauth2.user_provider"/>
             <argument type="service" id="security.encoder_factory"/>
         </service>
-        <service id="oauth2.storage.access_token" class="%oauth2.storage.access_token.class%">
+        <service id="oauth2.storage.access_token" class="%oauth2.storage.access_token.class%" public="true">
             <argument type="service" id="doctrine.orm.entity_manager"/>
         </service>
-        <service id="oauth2.storage.refresh_token" class="%oauth2.storage.refresh_token.class%">
+        <service id="oauth2.storage.refresh_token" class="%oauth2.storage.refresh_token.class%" public="true">
             <argument type="service" id="doctrine.orm.entity_manager"/>
         </service>
-        <service id="oauth2.storage.scope" class="%oauth2.storage.scope.class%">
+        <service id="oauth2.storage.scope" class="%oauth2.storage.scope.class%" public="true">
             <argument type="service" id="doctrine.orm.entity_manager"/>
             <argument type="service" id="oauth2.scope_manager"/>
         </service>
-        <service id="oauth2.storage.public_key" class="%oauth2.storage.public_key.class%" />
-        <service id="oauth2.storage.user_claims" class="%oauth2.storage.user_claims.class%" />
-        <service id="oauth2.grant_type.client_credentials" class="%oauth2.grant_type.client_credentials.class%">
+        <service id="oauth2.storage.public_key" class="%oauth2.storage.public_key.class%" public="true" />
+        <service id="oauth2.storage.user_claims" class="%oauth2.storage.user_claims.class%" public="true" />
+        <service id="oauth2.grant_type.client_credentials" class="%oauth2.grant_type.client_credentials.class%" public="true">
             <argument type="service" id="oauth2.storage.client_credentials"/>
         </service>
-        <service id="oauth2.grant_type.authorization_code" class="%oauth2.grant_type.authorization_code.class%">
+        <service id="oauth2.grant_type.authorization_code" class="%oauth2.grant_type.authorization_code.class%" public="true">
             <argument type="service" id="oauth2.storage.authorization_code"/>
         </service>
-        <service id="oauth2.grant_type.user_credentials" class="%oauth2.grant_type.user_credentials.class%">
+        <service id="oauth2.grant_type.user_credentials" class="%oauth2.grant_type.user_credentials.class%" public="true">
             <argument type="service" id="oauth2.storage.user_credentials"/>
         </service>
-        <service id="oauth2.grant_type.refresh_token" class="%oauth2.grant_type.refresh_token.class%">
+        <service id="oauth2.grant_type.refresh_token" class="%oauth2.grant_type.refresh_token.class%" public="true">
             <argument type="service" id="oauth2.storage.refresh_token"/>
             <argument type="collection">
                 <argument key="always_issue_new_refresh_token">false</argument>
             </argument>
         </service>
-        <service id="oauth2.client_manager" class="%oauth2.client_manager.class%">
+        <service id="oauth2.client_manager" class="%oauth2.client_manager.class%" public="true">
             <argument type="service" id="doctrine.orm.entity_manager"/>
             <argument type="service" id="oauth2.scope_manager"/>
         </service>

--- a/Storage/AccessToken.php
+++ b/Storage/AccessToken.php
@@ -4,7 +4,6 @@ namespace OAuth2\ServerBundle\Storage;
 
 use OAuth2\Storage\AccessTokenInterface;
 use Doctrine\ORM\EntityManager;
-use OAuth2\ServerBundle\Entity\Client;
 
 class AccessToken implements AccessTokenInterface
 {

--- a/Storage/AuthorizationCode.php
+++ b/Storage/AuthorizationCode.php
@@ -4,7 +4,6 @@ namespace OAuth2\ServerBundle\Storage;
 
 use OAuth2\Storage\AuthorizationCodeInterface;
 use Doctrine\ORM\EntityManager;
-use OAuth2\ServerBundle\Entity\Client;
 
 class AuthorizationCode implements AuthorizationCodeInterface
 {

--- a/Storage/ClientCredentials.php
+++ b/Storage/ClientCredentials.php
@@ -4,7 +4,6 @@ namespace OAuth2\ServerBundle\Storage;
 
 use OAuth2\Storage\ClientCredentialsInterface;
 use Doctrine\ORM\EntityManager;
-use OAuth2\ServerBundle\Entity\Client;
 
 class ClientCredentials implements ClientCredentialsInterface
 {

--- a/Storage/RefreshToken.php
+++ b/Storage/RefreshToken.php
@@ -2,8 +2,8 @@
 
 namespace OAuth2\ServerBundle\Storage;
 
-use OAuth2\Storage\RefreshTokenInterface;
 use Doctrine\ORM\EntityManager;
+use OAuth2\Storage\RefreshTokenInterface;
 
 class RefreshToken implements RefreshTokenInterface
 {

--- a/Storage/Scope.php
+++ b/Storage/Scope.php
@@ -2,9 +2,9 @@
 
 namespace OAuth2\ServerBundle\Storage;
 
-use OAuth2\Storage\ScopeInterface;
-use OAuth2\ServerBundle\Manager\ScopeManagerInterface;
 use Doctrine\ORM\EntityManager;
+use OAuth2\ServerBundle\Manager\ScopeManagerInterface;
+use OAuth2\Storage\ScopeInterface;
 
 class Scope implements ScopeInterface
 {

--- a/Storage/UserCredentials.php
+++ b/Storage/UserCredentials.php
@@ -2,13 +2,13 @@
 
 namespace OAuth2\ServerBundle\Storage;
 
-use OAuth2\Storage\UserCredentialsInterface;
 use Doctrine\ORM\EntityManager;
-use Symfony\Component\Security\Core\User\UserProviderInterface;
-use Symfony\Component\Security\Core\User\AdvancedUserInterface;
-use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
-use OAuth2\ServerBundle\User\OAuth2UserInterface;
 use OAuth2\ServerBundle\User\AdvancedOAuth2UserInterface;
+use OAuth2\ServerBundle\User\OAuth2UserInterface;
+use OAuth2\Storage\UserCredentialsInterface;
+use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
+use Symfony\Component\Security\Core\User\AdvancedUserInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
 
 class UserCredentials implements UserCredentialsInterface
 {

--- a/User/AdvancedOAuth2UserInterface.php
+++ b/User/AdvancedOAuth2UserInterface.php
@@ -18,7 +18,7 @@ interface AdvancedOAuth2UserInterface extends AdvancedUserInterface
      * </code>
      *
      *
-     * @return The user scope
+     * @return string The user scope
      */
     public function getScope();
 }

--- a/User/OAuth2UserInterface.php
+++ b/User/OAuth2UserInterface.php
@@ -18,7 +18,7 @@ interface OAuth2UserInterface extends UserInterface
      * </code>
      *
      *
-     * @return The user scope
+     * @return string The user scope
      */
     public function getScope();
 }

--- a/User/OAuth2UserProvider.php
+++ b/User/OAuth2UserProvider.php
@@ -121,7 +121,7 @@ class OAuth2UserProvider implements UserProviderInterface
     /**
      * Creates a salt for password hashing
      *
-     * @return A salt
+     * @return string A salt
      */
     protected function generateSalt()
     {

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,11 @@
     "name": "bshaffer/oauth2-server-bundle",
     "type": "symfony-bundle",
     "description": "Symfony OAuth2ServerBundle",
-    "keywords": ["oauth", "oauth2", "security"],
+    "keywords": [
+        "oauth",
+        "oauth2",
+        "security"
+    ],
     "homepage": "http://github.com/bshaffer/oauth2-server-bundle",
     "license": "MIT",
     "authors": [
@@ -11,18 +15,24 @@
             "email": "bshafs@gmail.com"
         }
     ],
-    "minimum-stability":"dev",
     "require": {
-        "php": ">=5.3",
+        "php": "^7.2",
         "bshaffer/oauth2-server-php": ">=1.0",
         "bshaffer/oauth2-server-httpfoundation-bridge": "^1.2"
     },
     "require-dev": {
-        "symfony/symfony": "^2.8|^3",
-        "doctrine/orm": "~2.4,>=2.4.5"
+        "doctrine/orm": "^2.4.5",
+        "phpunit/phpunit": "^5.7",
+        "sensio/framework-extra-bundle": "^5.0",
+        "symfony/symfony": "^3.0 || ^4.0"
     },
     "autoload": {
-        "psr-0": { "OAuth2\\ServerBundle": "" }
+        "psr-0": {
+            "OAuth2\\ServerBundle": ""
+        }
     },
-    "target-dir": "OAuth2/ServerBundle"
+    "target-dir": "OAuth2/ServerBundle",
+    "config": {
+        "sort-packages": true
+    }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit bootstrap="./Tests/bootstrap.php">
   <php>
-    <!-- <server name="CONTAINER_CONFIG" value="Tests/Resources/config/services.xml" /> -->
+     <server name="CONTAINER_CONFIG" value="Tests/Resources/config/services.xml" />
   </php>
   <testsuites>
     <testsuite name="OAuth2ServerBundle Test Suite">


### PR DESCRIPTION
This mainly concerns the service definitions. Since various services are fetched from the container directly, they must be declared public.
While debugging the oAuth flow, I also changed the deprecated routing annotations to ensure those weren't the problem, but these weren't required to get this thing running with Symfony 4 🙂

Could be released as `0.5` once merged.